### PR TITLE
storm: #15 - Fix timeout timer leak in agent spawning

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -41,57 +41,61 @@ export async function spawnAgent(
   // Read stdout line by line, parse stream-json
   let output = "";
   let usage: AgentUsage | undefined;
+  let exitCode = 0;
   const reader = proc.stdout.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
 
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
 
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const msg = JSON.parse(line);
-          if (msg.type === "result") {
-            output = msg.result || "";
-            if (msg.usage) {
-              usage = {
-                inputTokens: msg.usage.input_tokens ?? 0,
-                outputTokens: msg.usage.output_tokens ?? 0,
-                cacheReadTokens: msg.usage.cache_read_input_tokens ?? 0,
-                cacheCreationTokens: msg.usage.cache_creation_input_tokens ?? 0,
-              };
-            }
-          } else if (msg.type === "assistant" && msg.message?.content) {
-            for (const block of msg.message.content) {
-              if (block.type === "tool_use") {
-                log.dim(`  [tool] ${block.name}`);
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            if (msg.type === "result") {
+              output = msg.result || "";
+              if (msg.usage) {
+                usage = {
+                  inputTokens: msg.usage.input_tokens ?? 0,
+                  outputTokens: msg.usage.output_tokens ?? 0,
+                  cacheReadTokens: msg.usage.cache_read_input_tokens ?? 0,
+                  cacheCreationTokens: msg.usage.cache_creation_input_tokens ?? 0,
+                };
+              }
+            } else if (msg.type === "assistant" && msg.message?.content) {
+              for (const block of msg.message.content) {
+                if (block.type === "tool_use") {
+                  log.dim(`  [tool] ${block.name}`);
+                }
               }
             }
+          } catch {
+            // Not JSON, skip
           }
-        } catch {
-          // Not JSON, skip
         }
       }
+    } finally {
+      reader.releaseLock();
     }
+
+    // Also capture stderr
+    const stderr = await new Response(proc.stderr).text();
+    if (stderr.trim()) {
+      log.dim(`  [stderr] ${stderr.trim().slice(0, 200)}`);
+    }
+
+    exitCode = await proc.exited;
   } finally {
-    reader.releaseLock();
+    clearTimeout(timer);
   }
-
-  // Also capture stderr
-  const stderr = await new Response(proc.stderr).text();
-  if (stderr.trim()) {
-    log.dim(`  [stderr] ${stderr.trim().slice(0, 200)}`);
-  }
-
-  const exitCode = await proc.exited;
-  clearTimeout(timer);
 
   const done = output.includes(STOP_MARKER);
   const durationMs = Date.now() - start;


### PR DESCRIPTION
Closes #15

## Summary

**Fix timeout timer leak in agent spawning**

## Problem

In `src/core/agent.ts`, a `setTimeout` is used to kill the agent process after the configured timeout. However, if the process exits naturally before the timeout fires, the timer is never cleared:

```ts
const timer = setTimeout(() => {
  proc.kill();
  timedOut = true;
}, timeoutMs);

// ... process exits naturally ...
// timer is never clearTimeout(timer)'d
```

In a long-running `storm run` session processing many issues, this accumulates live timers that each hold a reference to the (already-dead) process object, preventing garbage collection. In extreme cases with many iterations or issues, this can cause memory pressure or unexpected delayed behavior if a timer fires after a new process has been assigned to the same variable.

## Solution

Clear the timer when the process exits naturally:

```ts
const timer = setTimeout(() => {
  proc.kill();
  timedOut = true;
}, timeoutMs);

try {
  // ... read stream ...
} finally {
  clearTimeout(timer);
}
```

The `finally` block ensures the timer is always cleared regardless of how the process terminates.

## Changes

- `src/core/agent.ts`

_1 file changed, 40 insertions(+), 36 deletions(-)_

## Considerations

<!-- Describe the key design decisions, trade-offs, or constraints that shaped this implementation. -->

## Test Plan

<!-- Outline the steps taken or recommended to verify correctness. -->

---

_Automatically generated by [storm-agent](https://github.com/codebypanduro/storm-agent) on branch `storm/issue-15-fix-timeout-timer-leak-in-agent-spawning`._
