### PR TITLE
storm: #14 - Add config validation on startup with clear error messages

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { loadConfig } from "../core/config.js";
+import { loadConfig, validateConfig } from "../core/config.js";
 import { CONFIG_DIR, ISSUE_START_MARKER, ISSUE_END_MARKER } from "../core/constants.js";
 import { log } from "../core/output.js";
 import { spawnAgent } from "../core/agent.js";
@@ -51,8 +51,9 @@ export async function generateCommand(cwd: string, options: GenerateOptions = {}
 
   const config = await loadConfig(cwd);
 
-  if (!config.github.repo) {
-    log.error('No repo configured. Set "repo" in .storm/storm.json');
+  const errors = validateConfig(config);
+  if (errors.length > 0) {
+    for (const err of errors) log.error(err);
     process.exit(1);
   }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from "../core/config.js";
+import { loadConfig, validateConfig } from "../core/config.js";
 import { fetchLabeledIssues } from "../core/github.js";
 import { log } from "../core/output.js";
 import pc from "picocolors";
@@ -6,8 +6,9 @@ import pc from "picocolors";
 export async function listCommand(cwd: string) {
   const config = await loadConfig(cwd);
 
-  if (!config.github.repo) {
-    log.error('No repo configured. Set "repo" in .storm/storm.json');
+  const errors = validateConfig(config);
+  if (errors.length > 0) {
+    for (const err of errors) log.error(err);
     process.exit(1);
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from "../core/config.js";
+import { loadConfig, validateConfig } from "../core/config.js";
 import { fetchLabeledIssues, fetchIssue } from "../core/github.js";
 import { processIssue, processIssueInWorktree, requestStop } from "../core/loop.js";
 import { log } from "../core/output.js";
@@ -18,8 +18,9 @@ export async function runCommand(
 
   const config = await loadConfig(cwd);
 
-  if (!config.github.repo) {
-    log.error('No repo configured. Set "repo" in .storm/storm.json');
+  const errors = validateConfig(config);
+  if (errors.length > 0) {
+    for (const err of errors) log.error(err);
     process.exit(1);
   }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from "../core/config.js";
+import { loadConfig, validateConfig } from "../core/config.js";
 import { listPullRequests } from "../core/github.js";
 import { runCommand } from "../primitives/runner.js";
 import { log } from "../core/output.js";
@@ -6,6 +6,12 @@ import pc from "picocolors";
 
 export async function statusCommand(cwd: string) {
   const config = await loadConfig(cwd);
+
+  const errors = validateConfig(config);
+  if (errors.length > 0) {
+    for (const err of errors) log.error(err);
+    process.exit(1);
+  }
 
   // List storm/* branches
   log.step("Local storm branches:");

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "bun:test";
+import { validateConfig, getDefaultConfig } from "./config.js";
+
+describe("validateConfig", () => {
+  it("returns no errors for a valid config", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "owner/repo";
+    expect(validateConfig(config)).toEqual([]);
+  });
+
+  it("errors when github.repo is empty", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "";
+    const errors = validateConfig(config);
+    expect(errors).toContain('github.repo is required (e.g. "owner/repo")');
+  });
+
+  it("errors when github.repo has no slash", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "justarepo";
+    const errors = validateConfig(config);
+    expect(errors).toContain('github.repo must be in "owner/repo" format');
+  });
+
+  it("does not double-error when repo is empty (no slash check)", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "";
+    const errors = validateConfig(config);
+    expect(errors).not.toContain('github.repo must be in "owner/repo" format');
+  });
+
+  it("errors when maxIterations is 0", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "owner/repo";
+    config.defaults.maxIterations = 0;
+    const errors = validateConfig(config);
+    expect(errors).toContain("defaults.maxIterations must be >= 1");
+  });
+
+  it("errors when maxIterations is negative", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "owner/repo";
+    config.defaults.maxIterations = -5;
+    const errors = validateConfig(config);
+    expect(errors).toContain("defaults.maxIterations must be >= 1");
+  });
+
+  it("errors when agent.command is empty", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "owner/repo";
+    config.agent.command = "";
+    const errors = validateConfig(config);
+    expect(errors).toContain("agent.command is required");
+  });
+
+  it("collects multiple errors", () => {
+    const config = getDefaultConfig();
+    config.github.repo = "";
+    config.defaults.maxIterations = 0;
+    config.agent.command = "";
+    const errors = validateConfig(config);
+    expect(errors.length).toBe(3);
+  });
+});

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -39,3 +39,12 @@ export async function loadConfig(cwd: string): Promise<StormConfig> {
 export function getDefaultConfig(): StormConfig {
   return structuredClone(DEFAULT_CONFIG);
 }
+
+export function validateConfig(config: StormConfig): string[] {
+  const errors: string[] = [];
+  if (!config.github.repo) errors.push('github.repo is required (e.g. "owner/repo")');
+  else if (!config.github.repo.includes("/")) errors.push('github.repo must be in "owner/repo" format');
+  if (config.defaults.maxIterations < 1) errors.push("defaults.maxIterations must be >= 1");
+  if (!config.agent.command) errors.push("agent.command is required");
+  return errors;
+}


### PR DESCRIPTION
Closes #14

## Summary

**Add config validation on startup with clear error messages**

## Problem

The `loadConfig()` function in `src/core/config.ts` merges user config with defaults but performs no validation. Invalid or incomplete configurations fail silently or produce confusing runtime errors:

- `github.repo` left empty (default is `""`) — the `run` command will call `parseRepo("")` and likely crash mid-execution after already starting git operations
- `agent.command` set to a non-existent binary — fails only when the agent is spawned
- `defaults.maxIterations` set to 0 or negative — causes an immediate no-op loop with no warning
- `github.label` left empty — fetches all open issues

## Solution

Add a `validateConfig()` function called at the start of `run`, `list`, `status`, and `generate` commands:

```ts
function validateConfig(config: StormConfig): string[] {
  const errors: string[] = [];
  if (!config.github.repo) errors.push('github.repo is required (e.g. "owner/repo")');
  if (!config.github.repo.includes('/')) errors.push('github.repo must be in "owner/repo" format');
  if (config.defaults.maxIterations < 1) errors.push('defaults.maxIterations must be >= 1');
  if (!config.agent.command) errors.push('agent.command is required');
  return errors;
}
```

Print all errors and exit with a non-zero code before any side effects occur. This prevents partial state (e.g., a branch created before discovering the GitHub token is missing).

## Changes

- `src/commands/generate.ts`
- `src/commands/list.ts`
- `src/commands/run.ts`
- `src/commands/status.ts`
- `src/core/config.test.ts`
- `src/core/config.ts`

_6 files changed, 92 insertions(+), 10 deletions(-)_

## Considerations

<!-- Describe the key design decisions, trade-offs, or constraints that shaped this implementation. -->

## Test Plan

<!-- Outline the steps taken or recommended to verify correctness. -->

---

_Automatically generated by [storm-agent](https://github.com/codebypanduro/storm-agent) on branch `storm/issue-14-add-config-validation-on-startup-with-clear-error-`._
