### PR TITLE
storm: #12 - Add unit test suite with Bun test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "bun run index.ts",
+    "test": "bun test",
     "typecheck": "bun tsc --noEmit"
   },
   "dependencies": {

--- a/src/__tests__/frontmatter.test.ts
+++ b/src/__tests__/frontmatter.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "bun:test";
+import { parsePrimitive } from "../primitives/frontmatter.js";
+
+describe("parsePrimitive", () => {
+  it("parses all frontmatter fields", () => {
+    const content = `---
+command: bun test
+description: Run tests
+enabled: true
+timeout: 30000
+completable: true
+---
+Body text here`;
+
+    const { frontmatter, body } = parsePrimitive(content);
+    expect(frontmatter.command).toBe("bun test");
+    expect(frontmatter.description).toBe("Run tests");
+    expect(frontmatter.enabled).toBe(true);
+    expect(frontmatter.timeout).toBe(30000);
+    expect(frontmatter.completable).toBe(true);
+    expect(body).toBe("Body text here");
+  });
+
+  it("defaults enabled to true when not specified", () => {
+    const content = `---
+command: echo hi
+---
+body`;
+    const { frontmatter } = parsePrimitive(content);
+    expect(frontmatter.enabled).toBe(true);
+  });
+
+  it("sets enabled to false when explicitly false", () => {
+    const content = `---
+enabled: false
+---
+body`;
+    const { frontmatter } = parsePrimitive(content);
+    expect(frontmatter.enabled).toBe(false);
+  });
+
+  it("handles missing optional fields as undefined", () => {
+    const content = `---
+command: ls
+---
+body`;
+    const { frontmatter } = parsePrimitive(content);
+    expect(frontmatter.description).toBeUndefined();
+    expect(frontmatter.timeout).toBeUndefined();
+    expect(frontmatter.completable).toBeUndefined();
+  });
+
+  it("trims whitespace from body", () => {
+    const content = `---
+command: ls
+---
+
+  body with whitespace
+`;
+    const { body } = parsePrimitive(content);
+    expect(body).toBe("body with whitespace");
+  });
+
+  it("handles content with no frontmatter", () => {
+    const content = "Just some plain body text";
+    const { frontmatter, body } = parsePrimitive(content);
+    expect(frontmatter.command).toBeUndefined();
+    expect(frontmatter.enabled).toBe(true);
+    expect(body).toBe("Just some plain body text");
+  });
+
+  it("handles empty frontmatter block", () => {
+    const content = `---
+---
+body`;
+    const { frontmatter, body } = parsePrimitive(content);
+    expect(frontmatter.command).toBeUndefined();
+    expect(frontmatter.enabled).toBe(true);
+    expect(body).toBe("body");
+  });
+
+  it("handles multiline body", () => {
+    const content = `---
+command: test
+---
+Line one
+Line two
+Line three`;
+    const { body } = parsePrimitive(content);
+    expect(body).toBe("Line one\nLine two\nLine three");
+  });
+});

--- a/src/__tests__/pr.test.ts
+++ b/src/__tests__/pr.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "bun:test";
+import { slugify, branchName } from "../core/pr.js";
+import type { GitHubIssue } from "../core/types.js";
+
+describe("slugify", () => {
+  it("lowercases text", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(slugify("foo bar baz")).toBe("foo-bar-baz");
+  });
+
+  it("replaces special characters with hyphens", () => {
+    expect(slugify("hello! world?")).toBe("hello-world");
+  });
+
+  it("collapses multiple consecutive non-alphanumeric chars into one hyphen", () => {
+    expect(slugify("a---b")).toBe("a-b");
+    expect(slugify("a   b")).toBe("a-b");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(slugify("  leading")).toBe("leading");
+    expect(slugify("trailing  ")).toBe("trailing");
+    expect(slugify("  both  ")).toBe("both");
+  });
+
+  it("handles unicode by stripping non-ascii characters", () => {
+    // Non-ascii chars are not a-z0-9 so they become hyphens
+    expect(slugify("café")).toMatch(/^caf/);
+  });
+
+  it("truncates to 50 characters", () => {
+    const long = "a".repeat(60);
+    expect(slugify(long).length).toBeLessThanOrEqual(50);
+  });
+
+  it("handles empty string", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  it("handles string with only special characters", () => {
+    expect(slugify("!@#$%")).toBe("");
+  });
+
+  it("handles numbers", () => {
+    expect(slugify("Issue 123")).toBe("issue-123");
+  });
+});
+
+describe("branchName", () => {
+  const issue: GitHubIssue = {
+    number: 12,
+    title: "Add unit test suite",
+    body: "",
+    labels: [],
+    url: "",
+  };
+
+  it("formats branch as storm/issue-{number}-{slug}", () => {
+    expect(branchName(issue)).toBe("storm/issue-12-add-unit-test-suite");
+  });
+
+  it("uses slugified title", () => {
+    const i: GitHubIssue = { ...issue, number: 7, title: "Fix: Bug in Auth!" };
+    expect(branchName(i)).toBe("storm/issue-7-fix-bug-in-auth");
+  });
+
+  it("handles issue with number only in name", () => {
+    const i: GitHubIssue = { ...issue, number: 1, title: "a" };
+    expect(branchName(i)).toBe("storm/issue-1-a");
+  });
+});

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "bun:test";
+import { resolveTemplate, resolveGenerateTemplate } from "../core/resolver.js";
+import type { GitHubIssue } from "../core/types.js";
+
+const baseIssue: GitHubIssue = {
+  number: 42,
+  title: "My Issue",
+  body: "Issue body text",
+  labels: ["bug"],
+  url: "https://github.com/owner/repo/issues/42",
+};
+
+describe("resolveTemplate", () => {
+  it("resolves issue.number", () => {
+    const result = resolveTemplate("Fix #{{ issue.number }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("Fix #42");
+  });
+
+  it("resolves issue.title", () => {
+    const result = resolveTemplate("Title: {{ issue.title }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("Title: My Issue");
+  });
+
+  it("resolves issue.body", () => {
+    const result = resolveTemplate("Body: {{ issue.body }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("Body: Issue body text");
+  });
+
+  it("resolves multiple issue placeholders in one template", () => {
+    const result = resolveTemplate(
+      "Fix {{ issue.title }} (#{{ issue.number }})",
+      { issue: baseIssue, contexts: new Map(), instructions: new Map() }
+    );
+    expect(result).toBe("Fix My Issue (#42)");
+  });
+
+  it("handles whitespace variants in placeholders", () => {
+    const result = resolveTemplate("{{issue.number}} and {{  issue.title  }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("42 and My Issue");
+  });
+
+  it("resolves named context placeholder", () => {
+    const contexts = new Map([["coding-standards", "Write clean code"]]);
+    const result = resolveTemplate("{{ contexts.coding-standards }}", {
+      issue: baseIssue,
+      contexts,
+      instructions: new Map(),
+    });
+    expect(result).toBe("Write clean code");
+  });
+
+  it("resolves named instruction placeholder", () => {
+    const instructions = new Map([["deploy", "Run bun deploy"]]);
+    const result = resolveTemplate("{{ instructions.deploy }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions,
+    });
+    expect(result).toBe("Run bun deploy");
+  });
+
+  it("resolves bulk {{ contexts }} with multiple entries", () => {
+    const contexts = new Map([
+      ["a", "Value A"],
+      ["b", "Value B"],
+    ]);
+    const result = resolveTemplate("{{ contexts }}", {
+      issue: baseIssue,
+      contexts,
+      instructions: new Map(),
+    });
+    expect(result).toBe("### a\nValue A\n\n### b\nValue B");
+  });
+
+  it("renders fallback for empty {{ contexts }}", () => {
+    const result = resolveTemplate("{{ contexts }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("_No contexts configured._");
+  });
+
+  it("renders fallback for empty {{ instructions }}", () => {
+    const result = resolveTemplate("{{ instructions }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("_No instructions configured._");
+  });
+
+  it("omits check failures block when not provided", () => {
+    const result = resolveTemplate("Before {{ checks.failures }} After", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("Before  After");
+  });
+
+  it("includes check failures block when provided", () => {
+    const result = resolveTemplate("{{ checks.failures }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+      checkFailures: "test failed",
+    });
+    expect(result).toContain("test failed");
+    expect(result).toContain("Previous Check Failures");
+  });
+
+  it("leaves unknown placeholders unchanged", () => {
+    const result = resolveTemplate("{{ unknown.placeholder }}", {
+      issue: baseIssue,
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("{{ unknown.placeholder }}");
+  });
+});
+
+describe("resolveGenerateTemplate", () => {
+  it("resolves named context placeholder", () => {
+    const contexts = new Map([["foo", "bar"]]);
+    const result = resolveGenerateTemplate("{{ contexts.foo }}", {
+      contexts,
+      instructions: new Map(),
+    });
+    expect(result).toBe("bar");
+  });
+
+  it("resolves named instruction placeholder", () => {
+    const instructions = new Map([["step", "do this"]]);
+    const result = resolveGenerateTemplate("{{ instructions.step }}", {
+      contexts: new Map(),
+      instructions,
+    });
+    expect(result).toBe("do this");
+  });
+
+  it("renders fallback for empty {{ contexts }}", () => {
+    const result = resolveGenerateTemplate("{{ contexts }}", {
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("_No contexts configured._");
+  });
+
+  it("renders fallback for empty {{ instructions }}", () => {
+    const result = resolveGenerateTemplate("{{ instructions }}", {
+      contexts: new Map(),
+      instructions: new Map(),
+    });
+    expect(result).toBe("_No instructions configured._");
+  });
+});


### PR DESCRIPTION
Closes #12

## Summary

**Add unit test suite with Bun test runner**

## Problem

The codebase has zero test files. There is no unit or integration test coverage for any of the core modules, including:

- `src/core/config.ts` — config loading and merging logic
- `src/core/resolver.ts` — template resolution with placeholder patterns
- `src/core/pr.ts` — `slugify()`, `branchName()`, `buildPRDescription()`
- `src/primitives/frontmatter.ts` — YAML frontmatter parsing
- `src/primitives/discovery.ts` — file discovery logic
- `src/core/checks.ts` — check aggregation and failure summary building

This makes it risky to refactor or extend any of the above without breaking existing behavior silently.

## Solution

Add a `src/__tests__/` directory using Bun's built-in test runner (`bun test`). Start with pure, side-effect-free functions:

```ts
// src/__tests__/resolver.test.ts
import { test, expect } from 'bun:test';
import { resolveTemplate } from '../core/resolver';

test('resolves issue placeholders', () => {
  const result = resolveTemplate('Fix {{ issue.title }} (#{{ issue.number }})', issue, ...);
  expect(result).toBe('Fix My Issue (#42)');
});
```

Add a `test` script to `package.json`:
```json
"scripts": { "test": "bun test" }
```

**Priority areas:**
1. `resolver.ts` — template resolution edge cases (missing keys, whitespace variants)
2. `pr.ts` — `slugify()` with special characters, unicode, long strings
3. `frontmatter.ts` — missing fields, invalid YAML, disabled flag
4. `config.ts` — partial configs, missing file, invalid JSON

## Changes

- `package.json`
- `src/__tests__/frontmatter.test.ts`
- `src/__tests__/pr.test.ts`
- `src/__tests__/resolver.test.ts`

_4 files changed, 340 insertions(+)_

## Considerations

<!-- Describe the key design decisions, trade-offs, or constraints that shaped this implementation. -->

## Test Plan

<!-- Outline the steps taken or recommended to verify correctness. -->

---

_Automatically generated by [storm-agent](https://github.com/codebypanduro/storm-agent) on branch `storm/issue-12-add-unit-test-suite-with-bun-test-runner`._
