### PR TITLE
Auto-detect linked PRs on issues and route to continue flow

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,5 +1,5 @@
 import { loadConfig, validateConfig } from "../core/config.js";
-import { fetchLabeledIssues } from "../core/github.js";
+import { fetchLabeledIssues, findLinkedPRs } from "../core/github.js";
 import { log } from "../core/output.js";
 import pc from "picocolors";
 
@@ -21,10 +21,17 @@ export async function listCommand(cwd: string) {
     return;
   }
 
+  const linkedPRs = await findLinkedPRs(
+    config.github.repo,
+    issues.map((i) => i.number)
+  );
+
   console.log("");
   for (const issue of issues) {
     const num = pc.bold(pc.cyan(`#${issue.number}`));
-    console.log(`  ${num}  ${issue.title}`);
+    const linked = linkedPRs.get(issue.number);
+    const prTag = linked ? pc.dim(` → PR #${linked.number}`) : "";
+    console.log(`  ${num}  ${issue.title}${prTag}`);
   }
   console.log("");
   log.info(`${issues.length} issue(s) found`);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,12 +1,21 @@
 import { loadConfig, validateConfig } from "../core/config.js";
-import { fetchLabeledIssues, fetchIssue } from "../core/github.js";
-import { processIssue, processIssueInWorktree, requestStop } from "../core/loop.js";
+import {
+  fetchLabeledIssues,
+  fetchIssue,
+  findLinkedPR,
+  fetchPullRequest,
+  fetchPRReviews,
+  fetchPRSessionId,
+} from "../core/github.js";
+import { processIssue, processIssueInWorktree, processContinue, requestStop } from "../core/loop.js";
 import { log } from "../core/output.js";
 import { CONFIG_DIR } from "../core/constants.js";
 import { loadContexts } from "../primitives/context.js";
 import { loadInstructions } from "../primitives/instructions.js";
-import { discoverWorkflow } from "../primitives/discovery.js";
-import { resolveTemplate } from "../core/resolver.js";
+import { discoverWorkflow, discoverContinueWorkflow } from "../primitives/discovery.js";
+import { resolveTemplate, resolveContinueTemplate } from "../core/resolver.js";
+import { runCommandArgs } from "../primitives/runner.js";
+import type { PRReviewContext } from "../core/types.js";
 import { existsSync } from "fs";
 import { join } from "path";
 
@@ -53,10 +62,11 @@ export async function runCommand(
     log.warn("Dry run mode — no agent will be spawned, no git operations will run");
     log.info(`Would process ${issues.length} issue(s):`);
 
-    const [contexts, instructions, workflow] = await Promise.all([
+    const [contexts, instructions, workflow, continueWorkflow] = await Promise.all([
       loadContexts(cwd),
       loadInstructions(cwd),
       discoverWorkflow(cwd),
+      discoverContinueWorkflow(cwd),
     ]);
 
     if (!workflow) {
@@ -66,10 +76,41 @@ export async function runCommand(
 
     for (const issue of issues) {
       log.issue(issue.number, issue.title);
-      const prompt = resolveTemplate(workflow.body, { issue, contexts, instructions });
-      log.dim("--- Resolved prompt ---");
-      console.log(prompt);
-      log.dim("--- End of prompt ---");
+
+      const linked = await findLinkedPR(config.github.repo, issue.number);
+      if (linked) {
+        log.info(`  Found linked PR #${linked.number} — would use continue flow`);
+        const pr = await fetchPullRequest(config.github.repo, linked.number);
+        const [reviews, sessionId] = await Promise.all([
+          fetchPRReviews(config.github.repo, linked.number),
+          fetchPRSessionId(config.github.repo, linked.number),
+        ]);
+        const diffResult = await runCommandArgs(
+          ["git", "diff", "--stat", `origin/${pr.baseBranch}...origin/${pr.headBranch}`],
+          { cwd }
+        );
+        const prContext: PRReviewContext = {
+          prNumber: linked.number,
+          prTitle: pr.title,
+          prBody: pr.body,
+          prBranch: pr.headBranch,
+          baseBranch: pr.baseBranch,
+          diffSummary: diffResult.stdout.trim(),
+          reviews,
+          linkedIssue: issue,
+          sessionId,
+        };
+        const template = continueWorkflow?.body ?? workflow.body;
+        const prompt = resolveContinueTemplate(template, { pr: prContext, contexts, instructions });
+        log.dim("--- Resolved continue prompt ---");
+        console.log(prompt);
+        log.dim("--- End of prompt ---");
+      } else {
+        const prompt = resolveTemplate(workflow.body, { issue, contexts, instructions });
+        log.dim("--- Resolved prompt ---");
+        console.log(prompt);
+        log.dim("--- End of prompt ---");
+      }
     }
 
     return;
@@ -81,7 +122,13 @@ export async function runCommand(
     // Parallel via worktrees
     log.info("Running in parallel with git worktrees");
     const results = await Promise.allSettled(
-      issues.map((issue) => processIssueInWorktree(issue, config, cwd))
+      issues.map(async (issue) => {
+        const linked = await findLinkedPR(config.github.repo, issue.number);
+        if (linked) {
+          return runContinueForLinkedPR(linked.number, issue, config, cwd);
+        }
+        return processIssueInWorktree(issue, config, cwd);
+      })
     );
 
     let succeeded = 0;
@@ -100,7 +147,13 @@ export async function runCommand(
     let succeeded = 0;
     let failed = 0;
     for (const issue of issues) {
-      const result = await processIssue(issue, config, cwd);
+      const linked = await findLinkedPR(config.github.repo, issue.number);
+      let result: { success: boolean };
+      if (linked) {
+        result = await runContinueForLinkedPR(linked.number, issue, config, cwd);
+      } else {
+        result = await processIssue(issue, config, cwd);
+      }
       if (result.success) {
         succeeded++;
       } else {
@@ -110,4 +163,38 @@ export async function runCommand(
 
     log.info(`Done: ${succeeded} succeeded, ${failed} failed`);
   }
+}
+
+async function runContinueForLinkedPR(
+  prNumber: number,
+  issue: import("../core/types.js").GitHubIssue,
+  config: import("../core/types.js").StormConfig,
+  cwd: string
+): Promise<{ success: boolean }> {
+  log.info(`Issue #${issue.number} has linked PR #${prNumber}, switching to continue flow`);
+
+  const pr = await fetchPullRequest(config.github.repo, prNumber);
+  const [reviews, sessionId] = await Promise.all([
+    fetchPRReviews(config.github.repo, prNumber),
+    fetchPRSessionId(config.github.repo, prNumber),
+  ]);
+
+  const diffResult = await runCommandArgs(
+    ["git", "diff", "--stat", `origin/${pr.baseBranch}...origin/${pr.headBranch}`],
+    { cwd }
+  );
+
+  const prContext: PRReviewContext = {
+    prNumber,
+    prTitle: pr.title,
+    prBody: pr.body,
+    prBranch: pr.headBranch,
+    baseBranch: pr.baseBranch,
+    diffSummary: diffResult.stdout.trim(),
+    reviews,
+    linkedIssue: issue,
+    sessionId,
+  };
+
+  return processContinue(prContext, config, cwd);
 }

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -154,6 +154,58 @@ export async function createIssue(
   return { number: data.number, url: data.html_url };
 }
 
+export async function findLinkedPR(
+  repoStr: string,
+  issueNumber: number
+): Promise<{ number: number; url: string } | null> {
+  const octokit = getOctokit();
+  const { owner, repo } = parseRepo(repoStr);
+
+  const { data: prs } = await octokit.pulls.list({
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+
+  const pattern = new RegExp(`(?:closes|fixes|resolves)\\s+#${issueNumber}\\b`, "i");
+  for (const pr of prs) {
+    if (pr.body && pattern.test(pr.body)) {
+      return { number: pr.number, url: pr.html_url };
+    }
+  }
+
+  return null;
+}
+
+export async function findLinkedPRs(
+  repoStr: string,
+  issueNumbers: number[]
+): Promise<Map<number, { number: number; url: string }>> {
+  const octokit = getOctokit();
+  const { owner, repo } = parseRepo(repoStr);
+
+  const { data: prs } = await octokit.pulls.list({
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+
+  const result = new Map<number, { number: number; url: string }>();
+  for (const pr of prs) {
+    if (!pr.body) continue;
+    for (const issueNumber of issueNumbers) {
+      const pattern = new RegExp(`(?:closes|fixes|resolves)\\s+#${issueNumber}\\b`, "i");
+      if (pattern.test(pr.body)) {
+        result.set(issueNumber, { number: pr.number, url: pr.html_url });
+      }
+    }
+  }
+
+  return result;
+}
+
 export async function listPullRequests(
   repoStr: string,
   head?: string


### PR DESCRIPTION
## Summary
- Add `findLinkedPR` and `findLinkedPRs` helpers in `src/core/github.ts` that scan open PR bodies for `Closes/Fixes/Resolves #N` patterns
- Update `storm list` to display linked PR numbers next to issues (e.g. `#42  Fix login bug  → PR #55`)
- Update `storm run` to detect linked PRs before processing — routes to the continue flow instead of creating duplicate branches/PRs, works in both sequential and parallel modes, and supports `--dry-run`

## Test plan
- [ ] `storm list` on a repo with issues that have linked PRs shows the PR numbers
- [ ] `storm run -i <N>` where issue N has an open PR routes to the continue flow (visible in logs)
- [ ] `storm run -i <N>` where issue N has no PR creates a new branch/PR as before
- [ ] `storm run --dry-run -i <N>` with a linked PR shows the continue template, not the create template
- [ ] Parallel mode (`storm run` with multiple issues) correctly routes each issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)