### PR TITLE
storm: #25 - GitHub API fetches are limited to 100 items with no pagination

### DIFF
--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -51,7 +51,7 @@ export async function fetchLabeledIssues(
   const octokit = getOctokit();
   const { owner, repo } = parseRepo(repoStr);
 
-  const { data } = await octokit.issues.listForRepo({
+  const data = await octokit.paginate(octokit.issues.listForRepo, {
     owner,
     repo,
     labels: label,
@@ -169,7 +169,7 @@ export async function listPullRequests(
   };
   if (head) params.head = `${owner}:${head}`;
 
-  const { data } = await octokit.pulls.list(params);
+  const data = await octokit.paginate(octokit.pulls.list, params);
 
   return data.map((pr) => ({
     number: pr.number,
@@ -208,9 +208,9 @@ export async function fetchPRReviews(
   const octokit = getOctokit();
   const { owner, repo } = parseRepo(repoStr);
 
-  const [{ data: reviews }, { data: comments }] = await Promise.all([
-    octokit.pulls.listReviews({ owner, repo, pull_number: prNumber, per_page: 100 }),
-    octokit.pulls.listReviewComments({ owner, repo, pull_number: prNumber, per_page: 100 }),
+  const [reviews, comments] = await Promise.all([
+    octokit.paginate(octokit.pulls.listReviews, { owner, repo, pull_number: prNumber, per_page: 100 }),
+    octokit.paginate(octokit.pulls.listReviewComments, { owner, repo, pull_number: prNumber, per_page: 100 }),
   ]);
 
   // Group comments by review ID, with top-level comments (no review) grouped separately
@@ -266,7 +266,7 @@ export async function fetchPRSessionId(
   const octokit = getOctokit();
   const { owner, repo } = parseRepo(repoStr);
 
-  const { data: comments } = await octokit.issues.listComments({
+  const comments = await octokit.paginate(octokit.issues.listComments, {
     owner,
     repo,
     issue_number: prNumber,


### PR DESCRIPTION
Closes #25

## Summary

**GitHub API fetches are limited to 100 items with no pagination**

## Problem

Both `fetchLabeledIssues` and `listPullRequests` in `src/core/github.ts` use `per_page: 100` with no pagination loop:

```typescript
const { data } = await octokit.issues.listForRepo({
  ...
  per_page: 100, // hard cap, no next-page handling
});
```

For repositories with more than 100 open storm-labeled issues (or more than 100 open storm PRs), items beyond the first page are silently dropped. The user will see an incomplete list and some issues will never be processed.

## Suggested fix

Use Octokit's built-in paginator:

```typescript
const data = await octokit.paginate(octokit.issues.listForRepo, {
  owner,
  repo,
  labels: label,
  state: "open",
  per_page: 100,
});
```

`octokit.paginate` automatically follows `Link: rel="next"` headers and returns all results, eliminating the silent truncation.

## Changes

- `src/core/github.ts`

_1 file changed, 6 insertions(+), 6 deletions(-)_

## Considerations

<!-- Describe the key design decisions, trade-offs, or constraints that shaped this implementation. -->

## Test Plan

<!-- Outline the steps taken or recommended to verify correctness. -->

---

_Automatically generated by [storm-agent](https://github.com/codebypanduro/storm-agent) on branch `storm/issue-25-github-api-fetches-are-limited-to-100-items-with-n`._
